### PR TITLE
Remove concept of NonEmptyObject

### DIFF
--- a/__tests__/core/type-system.test.ts
+++ b/__tests__/core/type-system.test.ts
@@ -21,7 +21,6 @@ import {
   ModelPropertiesDeclaration,
   SnapshotOut
 } from "../../src"
-import { $nonEmptyObject } from "../../src/internal"
 
 const createTestFactories = () => {
   const Box = types.model({
@@ -1151,7 +1150,6 @@ test("maybe / optional type inference verification", () => {
   assert(
     _ as ITC,
     _ as {
-      [$nonEmptyObject]?: any
       a: string
       b?: string
       c?: string | undefined
@@ -1163,7 +1161,6 @@ test("maybe / optional type inference verification", () => {
   assert(
     _ as ITS,
     _ as {
-      [$nonEmptyObject]?: any
       a: string
       b: string
       c: string | undefined
@@ -1171,4 +1168,28 @@ test("maybe / optional type inference verification", () => {
       e: string
     }
   )
+})
+
+test("#2186 substitutability for model types extending a common base", () => {
+  const BaseType = types.model()
+  const SubTypeOptional = BaseType.props({ a: "" })
+  const SubTypeRequired = BaseType.props({ a: types.string })
+  const SubTypeRequiredWithAnotherOptional = SubTypeRequired.props({
+    a: types.string,
+    b: 5
+  })
+
+  // a derived type with only-optional props should be assignable where the empty base is expected
+  true || ((t: typeof BaseType) => t.create())(SubTypeOptional)
+  // adding optional props to a type with required props preserves assignability
+  true ||
+    ((t: typeof SubTypeRequired) => t.create({ a: "123" }))(
+      SubTypeRequiredWithAnotherOptional
+    )
+  // adding a *required* prop breaks assignability to the empty base
+  true ||
+    ((t: typeof BaseType) => t.create())(
+      // @ts-expect-error -- a is required
+      SubTypeRequired
+    )
 })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,6 @@ export default defineConfig(
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unsafe-function-type": "off",
       "@typescript-eslint/no-empty-object-type": [
         "error",
         {

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -40,9 +40,10 @@ export interface IMiddlewareEvent extends IActionContext {
   readonly allParentIds: number[]
 }
 
-export interface FunctionWithFlag extends Function {
+export type FunctionWithFlag = ((...args: any[]) => any) & {
   _isMSTAction?: boolean
   _isFlowAction?: boolean
+  $mst_middleware?: IMiddleware[]
 }
 
 /**
@@ -84,7 +85,10 @@ export function getNextActionId() {
  * @internal
  * @hidden
  */
-export function runWithActionContext(context: IMiddlewareEvent, fn: Function) {
+export function runWithActionContext(
+  context: IMiddlewareEvent,
+  fn: (...args: any[]) => any
+) {
   const node = getStateTreeNode(context.context)
 
   if (context.type === "action") {
@@ -208,14 +212,17 @@ export function addMiddleware(
  * @param includeHooks
  * @returns The original function
  */
-export function decorate<T extends Function>(
+export function decorate<T extends (...args: any[]) => any>(
   handler: IMiddlewareHandler,
   fn: T,
   includeHooks = true
 ): T {
   const middleware: IMiddleware = { handler, includeHooks }
-  ;(fn as any).$mst_middleware = (fn as any).$mst_middleware || []
-  ;(fn as any).$mst_middleware.push(middleware)
+  const f = fn as FunctionWithFlag
+  if (!f.$mst_middleware) {
+    f.$mst_middleware = []
+  }
+  f.$mst_middleware.push(middleware)
   return fn
 }
 
@@ -224,10 +231,11 @@ class CollectedMiddlewares {
   private inArrayIndex = 0
   private middlewares: IMiddleware[][] = []
 
-  constructor(node: AnyObjectNode, fn: Function) {
+  constructor(node: AnyObjectNode, fn: (...args: any[]) => any) {
     // we just push middleware arrays into an array of arrays to avoid making copies
-    if ((fn as any).$mst_middleware) {
-      this.middlewares.push((fn as any).$mst_middleware)
+    const mw = (fn as FunctionWithFlag).$mst_middleware
+    if (mw) {
+      this.middlewares.push(mw)
     }
     let n: AnyObjectNode | null = node
     // Find all middlewares. Optimization: cache this?
@@ -261,7 +269,7 @@ class CollectedMiddlewares {
 function runMiddleWares(
   node: AnyObjectNode,
   baseCall: IMiddlewareEvent,
-  originalFn: Function
+  originalFn: (...args: any[]) => any
 ): any {
   const middlewares = new CollectedMiddlewares(node, originalFn)
   // Short circuit

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -288,7 +288,7 @@ function runMiddleWares(
     }
 
     // skip hooks if asked to
-    if (!middleware!.includeHooks && (Hook as any)[call.name]) {
+    if (!middleware!.includeHooks && call.name in Hook) {
       return runNextMiddleware(call)
     }
 

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -119,8 +119,14 @@ export function createFlowSpawner(name: string, generator: FunctionWithFlag) {
       parentActionEvent: parentActionContext
     }
 
-    function wrap(fn: any, type: IMiddlewareEventType, arg: any) {
-      fn.$mst_middleware = (spawner as any).$mst_middleware // pick up any middleware attached to the flow
+    const spawnerWithMw = spawner as FunctionWithFlag
+
+    function wrap(
+      fn: FunctionWithFlag,
+      type: IMiddlewareEventType,
+      arg: any
+    ) {
+      fn.$mst_middleware = spawnerWithMw.$mst_middleware // pick up any middleware attached to the flow
       return runWithActionContext(
         {
           ...contextBase,
@@ -132,12 +138,14 @@ export function createFlowSpawner(name: string, generator: FunctionWithFlag) {
     }
 
     return new Promise(function (resolve, reject) {
-      let gen: any
-      const init = function asyncActionInit(...initArgs: any[]) {
+      let gen: Generator<PromiseLike<unknown>, unknown, unknown>
+      const init = function asyncActionInit(
+        ...initArgs: any[]
+      ) {
         gen = generator(...initArgs)
         onFulfilled(undefined) // kick off the flow
-      }
-      ;(init as any).$mst_middleware = (spawner as any).$mst_middleware
+      } as FunctionWithFlag
+      init.$mst_middleware = spawnerWithMw.$mst_middleware
 
       runWithActionContext(
         {

--- a/src/core/mst-operations.ts
+++ b/src/core/mst-operations.ts
@@ -852,7 +852,6 @@ export function walk(
   assertIsFunction(processor, 2)
 
   const node = getStateTreeNode(target)
-  // tslint:disable-next-line:no_unused-variable
   node.getChildren().forEach(child => {
     if (isStateTreeNode(child.storedValue)) {
       walk(child.storedValue, processor)

--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -131,7 +131,10 @@ export function process(asyncAction: any): any {
  * @internal
  * @hidden
  */
-export function createProcessSpawner(name: string, generator: Function) {
+export function createProcessSpawner(
+  name: string,
+  generator: (...args: any[]) => any
+) {
   deprecated(
     "process",
     "`createProcessSpawner()` has been renamed to `createFlowSpawner()`. " +

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,6 @@ export type {
   ModelPropertiesDeclarationToProperties,
   ModelSnapshotType2,
   ModelSnapshotType,
-  NonEmptyObject,
   OnReferenceInvalidated,
   OnReferenceInvalidatedEvent,
   OptionalDefaultValueOrFunction,

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -839,8 +839,6 @@ export function model(...args: any[]): any {
   return new ModelType({ name, properties })
 }
 
-// TODO: this can be simplified in TS3, since we can transform _NotCustomized to unknown, since unkonwn & X = X
-// and then back unknown to _NotCustomized if needed
 /** @hidden */
 export type _CustomJoin<A, B> = A extends _NotCustomized ? B : A & B
 

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -459,11 +459,9 @@ export class ModelType<
 
       // the goal of this is to make sure actions using "this" can call themselves,
       // while still allowing the middlewares to register them
-      const middlewares = (action2 as any).$mst_middleware // make sure middlewares are not lost
-      const boundAction = action2.bind(actions)
-      boundAction._isFlowAction =
-        (action2 as FunctionWithFlag)._isFlowAction || false
-      boundAction.$mst_middleware = middlewares
+      const boundAction = action2.bind(actions) as FunctionWithFlag
+      boundAction._isFlowAction = action2._isFlowAction ?? false
+      boundAction.$mst_middleware = action2.$mst_middleware
       const actionInvoker = createActionInvoker(self as any, name, boundAction)
       actions[name] = actionInvoker
 

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -643,47 +643,45 @@ export class ModelType<
     observe(instance, this.didChange)
   }
 
-  private willChange(chg: IObjectWillChange): IObjectWillChange | null {
-    // TODO: mobx typings don't seem to take into account that newValue can be set even when removing a prop
-    const change = chg as IObjectWillChange & { newValue?: any }
-
+  private willChange(change: IObjectWillChange): IObjectWillChange | null {
     const node = getStateTreeNode(change.object)
     const subpath = change.name as string
     node.assertWritable({ subpath })
-    const childType = (node.type as this).properties[subpath]
-    // only properties are typed, state are stored as-is references
-    if (childType) {
-      typecheckInternal(childType, change.newValue)
-      change.newValue = childType.reconcile(
-        node.getChildNode(subpath),
-        change.newValue,
-        node,
-        subpath
-      )
+    // MST's removeChild sets the property to undefined rather than deleting it,
+    // so mobx only ever delivers "update"/"add" changes here, never "remove".
+    if (change.type !== "remove") {
+      const childType = (node.type as this).properties[subpath]
+      // only properties are typed, state are stored as-is references
+      if (childType) {
+        typecheckInternal(childType, change.newValue)
+        change.newValue = childType.reconcile(
+          node.getChildNode(subpath),
+          change.newValue,
+          node,
+          subpath
+        )
+      }
     }
     return change
   }
 
-  private didChange(chg: IObjectDidChange) {
-    // TODO: mobx typings don't seem to take into account that newValue can be set even when removing a prop
-    const change = chg as IObjectWillChange & { newValue?: any; oldValue?: any }
-
+  private didChange(change: IObjectDidChange) {
     const childNode = getStateTreeNode(change.object)
     const childType = (childNode.type as this).properties[change.name as string]
-    if (!childType) {
-      // don't emit patches for volatile state
-      return
+    // skip volatile state (no childType) and never-actually-occurring "remove" changes
+    if (childType && change.type !== "remove") {
+      const oldChildValue =
+        change.type === "update" ? change.oldValue.snapshot : undefined
+      childNode.emitPatch(
+        {
+          op: "replace",
+          path: escapeJsonPath(change.name as string),
+          value: change.newValue.snapshot,
+          oldValue: oldChildValue
+        },
+        childNode
+      )
     }
-    const oldChildValue = change.oldValue ? change.oldValue.snapshot : undefined
-    childNode.emitPatch(
-      {
-        op: "replace",
-        path: escapeJsonPath(change.name as string),
-        value: change.newValue.snapshot,
-        oldValue: oldChildValue
-      },
-      childNode
-    )
   }
 
   getChildren(node: this["N"]): ReadonlyArray<AnyNode> {

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -620,7 +620,7 @@ export class ModelType<
         objNode,
         name,
         undefined,
-        (initialSnapshot as any)[name]
+        initialSnapshot[name]
       )
     })
     return result

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -26,7 +26,6 @@ import {
   type IAnyType,
   type IChildNodesMap,
   type IJsonPatch,
-  type IStateTreeNode,
   type IType,
   type IValidationContext,
   type IValidationResult,
@@ -128,13 +127,13 @@ type DefinablePropsNames<T> = {
   [K in keyof T]: IsOptionalValue<T[K], never, K>
 }[keyof T]
 
-/** @hidden */
-export declare const $nonEmptyObject: unique symbol
+// Brand applied to the truly-empty object type so it doesn't structurally collapse to `{}`,
+// which TypeScript treats as "any non-nullish value". Kept internal; never exported.
+declare const $emptyObject: unique symbol
+type EmptyObject = { [$emptyObject]?: never }
 
 /** @hidden */
-export interface NonEmptyObject {
-  [$nonEmptyObject]?: any
-}
+export type MaybeEmpty<T> = keyof T extends never ? EmptyObject : T
 
 /** @hidden */
 export type ExtractCFromProps<P extends ModelProperties> = {
@@ -142,30 +141,21 @@ export type ExtractCFromProps<P extends ModelProperties> = {
 }
 
 /** @hidden */
-export type ModelCreationType<PC> = {
+export type ModelCreationType<PC> = MaybeEmpty<{
   [P in DefinablePropsNames<PC>]: PC[P]
-} & Partial<PC> &
-  NonEmptyObject
+}> &
+  Partial<PC>
 
 /** @hidden */
 export type ModelCreationType2<
   P extends ModelProperties,
   CustomC
-> = keyof P extends never
-  ? // When there are no props, we want to prevent passing in any object. We have two objects we want to allow:
-    //  1. The empty object
-    //  2. An instance of this model
-    //
-    // The `IStateTreeNode` interface allows both. For (1), these props are optional so an empty object is allowed.
-    // For (2), an instance will contain these two props, including the "secret" `$stateTreeNodeType` prop. TypeScript's
-    // excess property checking will then ensure no other props are passed in.
-    IStateTreeNode
-  : _CustomOrOther<CustomC, ModelCreationType<ExtractCFromProps<P>>>
+> = MaybeEmpty<_CustomOrOther<CustomC, ModelCreationType<ExtractCFromProps<P>>>>
 
 /** @hidden */
-export type ModelSnapshotType<P extends ModelProperties> = {
+export type ModelSnapshotType<P extends ModelProperties> = MaybeEmpty<{
   [K in keyof P]: P[K]["SnapshotType"]
-} & NonEmptyObject
+}>
 
 /** @hidden */
 export type ModelSnapshotType2<
@@ -179,7 +169,7 @@ export type ModelSnapshotType2<
  */
 export type ModelInstanceTypeProps<P extends ModelProperties> = {
   [K in keyof P]: P[K]["Type"]
-} & NonEmptyObject
+}
 
 /**
  * @hidden

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -77,7 +77,6 @@ export class CoreType<C, S, T> extends SimpleType<C, S, T> {
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const string: ISimpleType<string> = new CoreType<string, string, string>(
   "string",
   TypeFlags.String,
@@ -96,7 +95,6 @@ export const string: ISimpleType<string> = new CoreType<string, string, string>(
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const number: ISimpleType<number> = new CoreType<number, number, number>(
   "number",
   TypeFlags.Number,
@@ -114,7 +112,6 @@ export const number: ISimpleType<number> = new CoreType<number, number, number>(
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const integer: ISimpleType<number> = new CoreType<
   number,
   number,
@@ -132,7 +129,6 @@ export const integer: ISimpleType<number> = new CoreType<
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const float: ISimpleType<number> = new CoreType<number, number, number>(
   "float",
   TypeFlags.Float,
@@ -150,7 +146,6 @@ export const float: ISimpleType<number> = new CoreType<number, number, number>(
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const finite: ISimpleType<number> = new CoreType<number, number, number>(
   "finite",
   TypeFlags.Finite,
@@ -169,7 +164,6 @@ export const finite: ISimpleType<number> = new CoreType<number, number, number>(
  * })
  * ```
  */
-// tslint:disable-next-line:variable-name
 export const boolean: ISimpleType<boolean> = new CoreType<
   boolean,
   boolean,

--- a/src/types/primitives.ts
+++ b/src/types/primitives.ts
@@ -35,7 +35,6 @@ export class CoreType<C, S, T> extends SimpleType<C, S, T> {
     private readonly initializer: (v: C) => T = identity
   ) {
     super(name)
-    this.flags = flags
   }
 
   describe() {

--- a/src/types/utility-types/snapshotProcessor.ts
+++ b/src/types/utility-types/snapshotProcessor.ts
@@ -27,7 +27,6 @@ declare const $mstNotCustomized: unique symbol
 const $preProcessorFailed: unique symbol = Symbol("$preProcessorFailed")
 
 /** @hidden */
-// tslint:disable-next-line:class-name
 export interface _NotCustomized {
   // only for typings
   readonly [$mstNotCustomized]: undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -281,7 +281,7 @@ export function addHiddenWritableProp(
  * @internal
  * @hidden
  */
-export type ArgumentTypes<F extends Function> = F extends (
+export type ArgumentTypes<F extends (...args: any[]) => any> = F extends (
   ...args: infer A
 ) => any
   ? A
@@ -291,7 +291,7 @@ export type ArgumentTypes<F extends Function> = F extends (
  * @internal
  * @hidden
  */
-class EventHandler<F extends Function> {
+class EventHandler<F extends (...args: any[]) => any> {
   private handlers: F[] = []
   private emitting = false
   private pendingUnregisters: F[] | null = null
@@ -361,8 +361,12 @@ class EventHandler<F extends Function> {
  * @internal
  * @hidden
  */
-export class EventHandlers<E extends { [k: string]: Function }> {
-  private eventHandlers?: { [k in keyof E]?: EventHandler<Function> }
+export class EventHandlers<
+  E extends { [k: string]: (...args: any[]) => any }
+> {
+  private eventHandlers?: {
+    [k in keyof E]?: EventHandler<(...args: any[]) => any>
+  }
 
   hasSubscribers(event: keyof E): boolean {
     const handler = this.eventHandlers && this.eventHandlers[event]
@@ -448,7 +452,9 @@ export function stringStartsWith(str: string, beginning: string) {
  * @internal
  * @hidden
  */
-export type DeprecatedFunction = Function & { ids?: { [id: string]: true } }
+export type DeprecatedFunction = ((id: string, message: string) => void) & {
+  ids?: { [id: string]: true }
+}
 
 /**
  * @internal
@@ -536,7 +542,7 @@ export function assertArg<T>(
  * @hidden
  */
 export function assertIsFunction(
-  value: Function,
+  value: (...args: any[]) => any,
   argNumber: number | number[]
 ) {
   assertArg(value, fn => typeof fn === "function", "function", argNumber)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,22 +204,16 @@ export function freeze<T>(value: T): T {
  * Recursively freeze a value (if not in production)
  */
 export function deepFreeze<T>(value: T): T {
-  if (!devMode()) {
-    return value
-  }
-  freeze(value)
-
-  if (isPlainObject(value)) {
-    Object.keys(value).forEach(propKey => {
-      if (
-        !isPrimitive((value as any)[propKey]) &&
-        !Object.isFrozen((value as any)[propKey])
-      ) {
-        deepFreeze((value as any)[propKey])
+  if (devMode()) {
+    freeze(value)
+    if (isPlainObject(value)) {
+      for (const v of Object.values(value as Record<string, unknown>)) {
+        if (!isPrimitive(v) && !Object.isFrozen(v)) {
+          deepFreeze(v)
+        }
       }
-    })
+    }
   }
-
   return value
 }
 


### PR DESCRIPTION
this was a complex internal mobx-state-tree concept that repeatedly surfaced in our code that had to be filtered out of snapshots and most recently caused issue with mismatches mobx-state-tree versions after we changed how the internal type was exported

This PR just suggests removing it because modern typescript is sufficient to detect non-empty objects