### PR TITLE
Clean up snapshot hot path, type casts, and a latent getMembers crash

### DIFF
--- a/__tests__/core/model.test.ts
+++ b/__tests__/core/model.test.ts
@@ -228,6 +228,31 @@ describe("Model instantiation", () => {
         })
       ).toThrow("[mobx-state-tree] name property is declared twice")
     })
+
+    test("an action reusing a property name is rejected", () => {
+      const M = types
+        .model("M", { name: types.string })
+        .actions(() => ({
+          name() {}
+        }))
+
+      expect(() => M.create({ name: "a" })).toThrow(
+        "[mobx-state-tree] name property is declared twice"
+      )
+    })
+
+    test("a composed view shadowing a base property is rejected", () => {
+      const Base = types.model("Base", { name: types.string })
+      const WithView = types.model("WithView", {}).views(() => ({
+        get name() {
+          return "x"
+        }
+      }))
+
+      expect(() => types.compose(Base, WithView).create({ name: "a" })).toThrow(
+        "[mobx-state-tree] name property is declared twice"
+      )
+    })
   })
 })
 describe("Model properties objects", () => {

--- a/__tests__/perf/mst.bench.ts
+++ b/__tests__/perf/mst.bench.ts
@@ -3,8 +3,8 @@ import { readFileSync } from "fs"
 import { join } from "path"
 
 // Import from both built branches
-import * as mstBranch1 from "../../dist_branch1/mobx-state-tree.module.js"
-import * as mstBranch2 from "../../dist_branch2/mobx-state-tree.module.js"
+import * as mstBranch1 from "../../dist_branch1/mobx-state-tree.mjs"
+import * as mstBranch2 from "../../dist_branch2/mobx-state-tree.mjs"
 
 // Read branch names
 const branch1Name = readFileSync(

--- a/src/core/mst-operations.ts
+++ b/src/core/mst-operations.ts
@@ -714,7 +714,7 @@ export function getRelativePath(
  */
 export function clone<T extends IAnyStateTreeNode>(
   source: T,
-  keepEnvironment: boolean | any = true
+  keepEnvironment: boolean | object = true
 ): T {
   // check all arguments
   assertIsStateTreeNode(source, 1)
@@ -932,10 +932,11 @@ export function getMembers(target: IAnyStateTreeNode): IModelReflectionData {
       }
       return
     }
-    if (descriptor.value._isFlowAction === true) {
+    const value = descriptor.value
+    if (value?._isFlowAction === true) {
       reflected.flowActions.push(key)
     }
-    if (descriptor.value._isMSTAction === true) {
+    if (value?._isMSTAction === true) {
       reflected.actions.push(key)
     } else if (isObservableProp(target, key)) {
       reflected.volatile.push(key)

--- a/src/types/complex-types/model.ts
+++ b/src/types/complex-types/model.ts
@@ -7,7 +7,10 @@ import {
   computed,
   defineProperty,
   getAtom,
+  type IAtom,
   intercept,
+  isComputedProp,
+  isObservableProp,
   makeObservable,
   observable,
   observe,
@@ -405,6 +408,9 @@ export class ModelType<
   private preProcessor!: (snapshot: any) => any | undefined
   private postProcessor!: (snapshot: any) => any | undefined
   readonly propertyNames: string[]
+  // member/property name collisions are a property of the type, so we only need
+  // to check the first instance we finalize (see finalizeNewInstance)
+  private duplicateKeysChecked = false
 
   constructor(opts: ModelTypeConfig) {
     super(opts.name || defaultObjectOptions.name)
@@ -666,6 +672,23 @@ export class ModelType<
     })
 
     this.initializers.reduce((self, fn) => fn(self), instance)
+
+    // views, actions and volatile share the instance namespace with properties,
+    // so a view/action reusing a property name silently clobbers that property's
+    // observable value. It's a type-level mistake (identical for every instance),
+    // so we check just the first one we finalize: a healthy property stays a
+    // plain observable, a shadowing getter becomes a computed, and a shadowing
+    // function/value stops being observable at all. The flag is only set on
+    // success so a broken type keeps throwing on every create.
+    if (!this.duplicateKeysChecked) {
+      this.forAllProps(name => {
+        if (isComputedProp(instance, name) || !isObservableProp(instance, name)) {
+          throw fail(`${name} property is declared twice`)
+        }
+      })
+      this.duplicateKeysChecked = true
+    }
+
     intercept(instance, this.willChange)
     observe(instance, this.didChange)
   }
@@ -734,13 +757,11 @@ export class ModelType<
   override getSnapshot(node: this["N"], applyPostProcess = true): this["S"] {
     const res = {} as any
     this.forAllProps((name, type) => {
-      try {
-        // TODO: FIXME, make sure the observable ref is used!
-        const atom = getAtom(node.storedValue, name)
-        ;(atom as any).reportObserved()
-      } catch (_e) {
-        throw fail(`${name} property is declared twice`)
-      }
+      // observe the property's atom so the snapshot computed recomputes when a
+      // child is reassigned (getChildNode below reads via raw() and won't
+      // track). mobx types getAtom's return as the bare IDepTreeNode, so we
+      // narrow to IAtom to reach reportObserved.
+      ;(getAtom(node.storedValue, name) as IAtom).reportObserved()
       const snapshot = this.getChildNode(node, name).snapshot
       // strip-default optionals omit their key when equal to the default
       if (!shouldStripChildFromSnapshot(type, snapshot)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -323,7 +323,7 @@ class EventHandler<F extends (...args: any[]) => any> {
  */
 export class EventHandlers<E extends { [k: string]: (...args: any[]) => any }> {
   private eventHandlers?: {
-    [k in keyof E]?: EventHandler<(...args: any[]) => any>
+    [k in keyof E]?: EventHandler<E[k]>
   }
 
   hasSubscribers(event: keyof E): boolean {
@@ -369,7 +369,7 @@ export class EventHandlers<E extends { [k: string]: (...args: any[]) => any }> {
   emit<N extends keyof E>(event: N, ...args: ArgumentTypes<E[N]>) {
     const handler = this.eventHandlers?.[event]
     if (handler) {
-      ;(handler.emit as any)(...args)
+      handler.emit(...args)
     }
   }
 }


### PR DESCRIPTION
## Summary

A few focused cleanups to the core types and the snapshot hot path, each verified perf-neutral against the benchmark.

- **`getSnapshot` hot path** (`model.ts`): the per-property `try/catch` that detected view/action-vs-property name collisions is removed. That detection is a property of the *type* (identical for every instance), so it moves to a **once-per-type** check in `finalizeNewInstance` using mobx's `isComputedProp`/`isObservableProp`. The flag is only set on success, so a broken type keeps throwing on every `create()`. The one remaining `getAtom` call is narrowed from `as any` to the typed `as IAtom` (mobx types `getAtom`'s return too loosely to reach `reportObserved` otherwise), with a comment explaining why.
- **`EventHandlers`** (`utils.ts`): stop erasing the handler function type in the internal map (`EventHandler<E[k]>` instead of `EventHandler<(...args: any[]) => any>`), so `emit` no longer needs `as any`.
- **`getMembers`** (`mst-operations.ts`): read `descriptor.value` once via optional chaining — fixes a latent crash on a setter-only property (`descriptor.value` undefined) and removes a triple property access.
- **`clone`** (`mst-operations.ts`): `keepEnvironment: boolean | any` (which collapses to `any`) becomes `boolean | object`.
- **perf bench** (`mst.bench.ts`): fix a stale import (`.module.js` → `.mjs`) left behind when the build output was renamed, so `pnpm bench` runs again.

## Tests

- Added regression tests for an **action** reusing a property name and a **composed** view shadowing a base property (previously only the view-getter case was covered).
- `tsc`, lint, dev suite (1068 passing), prod suite (956 passing), and type tests all pass.

## Performance

The duplicate-key detection was moved, not dropped — `create()` is lazy so it never triggered child finalization, but `applySnapshot` does. An initial approach that checked on every instance regressed `applySnapshot` ~1.8x; the once-per-type check restores parity (micro-bench: 1640ms vs 1616ms baseline, within noise). Full comparative bench shows all scenarios within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)