### PR TITLE
Make keyed array reconciliation O(n) instead of O(n²)

### DIFF
--- a/__tests__/core/array.test.ts
+++ b/__tests__/core/array.test.ts
@@ -301,6 +301,41 @@ test("it should reconciliate keyed instances correctly", () => {
   expect(store.todos[1] === coffee).toBe(true)
   expect(store.todos[2] === biscuit).toBe(false)
 })
+test("keyed reconciliation reuses moved nodes and drops replaced ones", () => {
+  const Task = types.model("Task", { id: types.identifier, task: "" })
+  const Store = types.model({ todos: types.array(Task) })
+  const store = Store.create({
+    todos: Array.from({ length: 20 }, (_, i) => ({
+      id: `${i}`,
+      task: `t${i}`
+    }))
+  })
+  const first = store.todos[0]
+  const last = store.todos[19]
+
+  // move last to front, keep first: matching ids must reuse the same instances
+  applySnapshot(store, {
+    todos: [
+      { id: "19", task: "t19" },
+      { id: "0", task: "t0" },
+      { id: "5", task: "t5" }
+    ]
+  })
+  expect(store.todos.map(t => t.id)).toEqual(["19", "0", "5"])
+  expect(store.todos[0] === last).toBe(true)
+  expect(store.todos[1] === first).toBe(true)
+
+  // full replacement with all-new ids: no reuse possible, all fresh nodes
+  const before = store.todos.slice()
+  applySnapshot(store, {
+    todos: [
+      { id: "100", task: "a" },
+      { id: "101", task: "b" }
+    ]
+  })
+  expect(store.todos.map(t => t.id)).toEqual(["100", "101"])
+  expect(before.some(t => store.todos.includes(t))).toBe(false)
+})
 test("it correctly reconciliate when swapping", () => {
   const Task = types.model("Task", {})
   const Store = types.model({

--- a/__tests__/perf/mst.bench.ts
+++ b/__tests__/perf/mst.bench.ts
@@ -3,8 +3,8 @@ import { readFileSync } from "fs"
 import { join } from "path"
 
 // Import from both built branches
-import * as mstBranch1 from "../../dist_branch1/mobx-state-tree.module.js"
-import * as mstBranch2 from "../../dist_branch2/mobx-state-tree.module.js"
+import * as mstBranch1 from "../../dist_branch1/mobx-state-tree.mjs"
+import * as mstBranch2 from "../../dist_branch2/mobx-state-tree.mjs"
 
 // Read branch names
 const branch1Name = readFileSync(

--- a/src/types/complex-types/array.ts
+++ b/src/types/complex-types/array.ts
@@ -44,7 +44,9 @@ import {
   isPlainObject,
   isStateTreeNode,
   isType,
+  ModelType,
   mobxShallow,
+  normalizeIdentifier,
   popContext,
   typeCheckFailure,
   typeCheckSuccess,
@@ -391,6 +393,24 @@ function reconcileArrayChildren<TT>(
 ): AnyNode[] | null {
   let nothingChanged = true
 
+  // When the element type is a plain model with an identifier, index the old
+  // nodes by id so a moved / replaced child is matched in O(1) instead of the
+  // linear scan in the reorder branch below. This turns a full array
+  // replacement (the common "load new data" case) from O(n^2) into O(n). Types
+  // whose id extraction needs type-specific preprocessing (union,
+  // snapshotProcessor, late, ...) are intentionally excluded: areSame must run
+  // `is()` before their id check, so they stay on the scan path.
+  let idIndex: { attr: string; byId: Map<string, AnyNode> } | undefined
+  if (childType instanceof ModelType && childType.identifierAttribute) {
+    const byId = new Map<string, AnyNode>()
+    for (const n of oldNodes) {
+      if (n instanceof ObjectNode && n.identifier !== null) {
+        byId.set(n.identifier, n)
+      }
+    }
+    idIndex = { attr: childType.identifierAttribute, byId }
+  }
+
   for (let i = 0; ; i++) {
     const hasNewNode = i <= newValues.length - 1
     const oldNode = oldNodes[i]
@@ -438,14 +458,28 @@ function reconcileArrayChildren<TT>(
       // both are the same, reconcile
       oldNodes[i] = valueAsNode(childType, parent, newPath, newValue, oldNode)
     } else {
-      // nothing to do, try to reorder
+      // nothing to do, try to reorder: find a candidate old node to reuse
       let oldMatch = undefined
 
-      // find a possible candidate to reuse
-      for (let j = i; j < oldNodes.length; j++) {
-        if (areSame(oldNodes[j]!, newValue)) {
+      if (idIndex && isPlainObject(newValue)) {
+        // for an identified element type a plain-object snapshot can only match
+        // by id (it is never a live node, and snapshot-reference equality still
+        // implies the same id), so a miss means "nothing to reuse" without
+        // scanning. areSame still verifies the single candidate.
+        const candidate = idIndex.byId.get(
+          normalizeIdentifier(newValue[idIndex.attr])
+        )
+        const j = candidate ? oldNodes.indexOf(candidate, i) : -1
+        if (j >= i && areSame(oldNodes[j]!, newValue)) {
           oldMatch = oldNodes.splice(j, 1)[0]
-          break
+        }
+      } else {
+        // find a possible candidate to reuse
+        for (let j = i; j < oldNodes.length; j++) {
+          if (areSame(oldNodes[j]!, newValue)) {
+            oldMatch = oldNodes.splice(j, 1)[0]
+            break
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

`reconcileArrayChildren` matches each new value to a reusable old node; when the aligned position doesn't match, it linearly scans the remaining old nodes with `areSame` (which runs a deep `is()` type check). For a **full array replacement** — new identifiers at every position, i.e. the common "load new data" case — nothing ever matches, so every position scans to the end: **O(n²)**, with a deep validation at each step.

This indexes the old nodes by identifier once, and resolves the reorder match by lookup. A **miss is O(1)**, so a full replacement is now **O(n)**.

## Why it's safe

The fast path is used **only** when the element type is a plain model with an identifier. Union / snapshotProcessor element types keep the existing scan, because their identifier extraction runs type-specific preprocessing that must stay behind `areSame`'s `is()` type guard (running it on the wrong subtype can throw/misbehave). The single candidate found by id lookup is still verified with `areSame`, so behavior is identical to the scan — this only skips work that could never have matched.

## Performance

Full-array replacement via `applySnapshot` (all-new ids), per call:

| n | fix | baseline | speedup |
|---|-----|----------|---------|
| 100 | 3.6ms | 7.2ms | 2.0x |
| 250 | 8.5ms | 29ms | 3.4x |
| 500 | 17ms | 103ms | 6.0x |
| 1000 | 34ms | 355ms | **10.3x** |

The fix scales linearly (n×10 → ~time×10); baseline is quadratic (time×49). The rest of the benchmark suite is within noise, and union-array scenarios (scan path) are unchanged.

## Tests

All existing reconciliation tests pass unchanged — keyed reorder with node-identity preservation, swapping, and the union + snapshotProcessor + identifier cases. Added a focused test covering a large reorder (identity preserved) and a full replacement (all-new nodes). dev: 1067 passing, prod: 955, type tests pass.

Also fixes the perf bench's stale import (`.module.js` → `.mjs`) so `pnpm bench` runs against the current build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)