### PR TITLE
Remove validation result cache

### DIFF
--- a/src/core/type/type.ts
+++ b/src/core/type/type.ts
@@ -25,13 +25,6 @@ import {
   type ScalarNode
 } from "../../internal.ts"
 
-// Cache for validation results to avoid re-validating the same object against the same type
-// Uses WeakMap so cached objects can be garbage collected
-const validationCache = new WeakMap<
-  object,
-  WeakMap<BaseType<any, any, any, any>, IValidationResult>
->()
-
 /**
  * @internal
  * @hidden
@@ -376,30 +369,7 @@ export abstract class BaseType<
       // it is tempting to compare snapshots, but in that case we should always clone on assignments...
     }
 
-    // check cache for object values (only at root level to avoid context mismatches)
-    if (typeof value === "object" && value !== null && context.length === 1) {
-      const typeCache = validationCache.get(value)
-      if (typeCache) {
-        const cached = typeCache.get(this)
-        if (cached !== undefined) {
-          return cached
-        }
-      }
-    }
-
-    const result = this.isValidSnapshot(value as C, context)
-
-    // cache result for object values (only at root level)
-    if (typeof value === "object" && value !== null && context.length === 1) {
-      let typeCache = validationCache.get(value)
-      if (!typeCache) {
-        typeCache = new WeakMap()
-        validationCache.set(value, typeCache)
-      }
-      typeCache.set(this, result)
-    }
-
-    return result
+    return this.isValidSnapshot(value as C, context)
   }
 
   is(thing: any): thing is any {


### PR DESCRIPTION
## What

Deletes the per-`(value, type)` validation `WeakMap` in `BaseType.validate`.

## Why

The cache (added in `a1fe5ae0`) was a band-aid over the **O(n²) `is()` scan** in keyed-array reconciliation. Now that plain identified arrays reconcile in O(n) (#13), the cache's *only* remaining benefit is masking that scan when an **already-populated union array** is replaced or reordered.

Measured `validate()` cache hit rates (production, N=200):

| scenario | hits | total |
|---|---|---|
| frozen array replace-all | **0** | 201 |
| plain identified replace-all | **0** | 1601 |
| union array **initial load** (empty→fill) | **0** | 300 |
| union array replace-all | 39800 (=200×199) | 43301 |

So the cache does nothing for array construction, frozen arrays, plain identified arrays, or initial loads. It only helps wholesale-replacing an already-populated *union* array — not a hot path (and in jbrowse, web uses frozen tracks, while desktop's cost is model hydration and its common op is initial load).

It also carried a latent **staleness bug**: results are keyed by object identity and never invalidated, so mutating a snapshot object between validations returned a stale result. Removing the cache eliminates that footgun and simplifies the validation hot path.

## Tradeoff

Wholesale-replacing a large *populated* union array regresses ~2.6× (back to the underlying O(n²) scan). Making union arrays O(n) is a possible follow-up that would remove even that; it's deliberately out of scope here.

## Verification

`tsc --noEmit`, `pnpm lint src/`, `test:dev` (1069), `test:prod` (957), `test:types` — all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)