### PR TITLE
Remove dead second loop in union determineType

### DIFF
--- a/src/types/utility-types/union.ts
+++ b/src/types/utility-types/union.ts
@@ -219,21 +219,13 @@ export class Union extends BaseType<any, any, any> {
       return this._dispatcher(value)
     }
 
-    // fast path: when type checking is disabled, try quick structural matching first
+    // fast path: when type checking is disabled, try quick structural matching
+    // first. This skips full recursive validation of every property value, a
+    // meaningful win for wide model members (e.g. jbrowse config schemas).
     if (!isTypeCheckingEnabled()) {
       const quickMatch = this.tryQuickMatch(value, reconcileCurrentType)
       if (quickMatch) {
         return quickMatch
-      }
-      // for plain object snapshots that didn't match via quick path, try all types
-      // with quick matching before falling back to full validation
-      // (state tree nodes must go through full validation for type identity checks)
-      if (isPlainObject(value) && !isStateTreeNode(value)) {
-        for (const type of this._types) {
-          if (this.snapshotLooksLikeType(value, type)) {
-            return type
-          }
-        }
       }
     }
 


### PR DESCRIPTION
## What

Removes a redundant loop in `Union.determineType`'s production fast path.

## Why

The fast path did:

```ts
const quickMatch = this.tryQuickMatch(value, reconcileCurrentType)
if (quickMatch) return quickMatch
// then, for plain non-node objects, loop this._types again with snapshotLooksLikeType
```

But for a plain object `tryQuickMatch` *already* loops the identical set of types with the identical `snapshotLooksLikeType` predicate. If it returns `undefined`, no type satisfied the predicate — so the second loop over the same set with the same predicate can never find a match `tryQuickMatch` missed. It's dead code.

## Verification

- **Logical**: same predicate over same set ⇒ same result.
- **Empirical**: instrumented the loop to throw if it ever fired; full dev + prod suites (2026 tests) pass unchanged — it never fires.
- `tsc`, `pnpm lint src/`, `test:types` clean.

## Note

`tryQuickMatch` itself is **kept** — benchmarked ~1.5× faster union hydration for wide model members (177ms → 115ms, N=2000, ~44 slots each, like jbrowse config schemas) because it skips full recursive per-property validation. Only the duplicate loop is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)