### PR TITLE
Fix reentrant emit skipping handlers in EventHandler

### DIFF
--- a/__tests__/core/event-handler.test.ts
+++ b/__tests__/core/event-handler.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest"
+import { EventHandlers } from "../../src/utils.ts"
+
+// A handler removed mid-emit must still run in an emit that was already in
+// progress when the removal happened (classic copy-on-emit semantics). The
+// reentrant inner emit below must not corrupt the outer emit's iteration.
+test("reentrant emit does not skip handlers unregistered during the outer emit", () => {
+  const eh = new EventHandlers<{ x: () => void }>()
+  const calls: string[] = []
+  let reentered = false
+
+  const a = () => {
+    calls.push("a")
+    if (!reentered) {
+      reentered = true
+      eh.emit("x") // reentrant emit while the outer emit is still running
+    }
+  }
+  const b = () => {
+    calls.push("b")
+    eh.unregister("x", c)
+  }
+  const c = () => {
+    calls.push("c")
+  }
+
+  eh.register("x", a)
+  eh.register("x", b)
+  eh.register("x", c)
+
+  eh.emit("x")
+
+  // outer emit began with [a, b, c] registered, so c must run in it even though
+  // b unregisters c; the trailing "c" is the outer emit's call.
+  expect(calls[calls.length - 1]).toBe("c")
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -253,8 +253,6 @@ export type ArgumentTypes<F extends (...args: any[]) => any> = F extends (
  */
 class EventHandler<F extends (...args: any[]) => any> {
   private handlers: F[] = []
-  private emitting = false
-  private pendingUnregisters: F[] | null = null
 
   get hasSubscribers(): boolean {
     return this.handlers.length > 0
@@ -276,14 +274,6 @@ class EventHandler<F extends (...args: any[]) => any> {
   }
 
   unregister(fn: F) {
-    if (this.emitting) {
-      // defer unregistration until emit is done
-      if (!this.pendingUnregisters) {
-        this.pendingUnregisters = []
-      }
-      this.pendingUnregisters.push(fn)
-      return
-    }
     const index = this.handlers.indexOf(fn)
     if (index >= 0) {
       this.handlers.splice(index, 1)
@@ -295,25 +285,10 @@ class EventHandler<F extends (...args: any[]) => any> {
   }
 
   emit(...args: ArgumentTypes<F>) {
-    // use emitting flag to defer unregistrations instead of copying array
-    this.emitting = true
-    try {
-      for (const f of this.handlers) {
-        f(...args)
-      }
-    } finally {
-      this.emitting = false
-      // process any deferred unregistrations
-      if (this.pendingUnregisters) {
-        for (const fn of this.pendingUnregisters) {
-          const index = this.handlers.indexOf(fn)
-          if (index >= 0) {
-            this.handlers.splice(index, 1)
-          }
-        }
-        this.pendingUnregisters = null
-      }
-    }
+    // iterate a copy so (un)registrations during emit don't disturb this pass
+    // and reentrant emits stay correct
+    const handlers = this.handlers.slice()
+    handlers.forEach(f => f(...args))
   }
 }
 


### PR DESCRIPTION
## Bug

`EventHandler.emit` (from `a1fe5ae0`) uses an `emitting` boolean plus deferred unregistration instead of copying the handler list. A boolean can't track emit **depth**, so it's not reentrancy-safe:

1. Outer `emit()` sets `emitting = true` and iterates the live `handlers` array.
2. A handler triggers a nested `emit()` on the same `EventHandler`; that inner emit's `finally` sets `emitting = false` — even though the outer emit is still running.
3. A later handler in the outer emit calls `unregister()`. Because `emitting` is now `false`, it splices the live array **mid-iteration**, and the outer `for…of` skips a handler that was present when that emit began.

## Fix

Revert `emit()` to the classic copy-on-emit (`this.handlers.slice()`), which is reentrancy-safe by construction and makes `register`/`unregister` trivial again (no `emitting` flag, no `pendingUnregisters`). Handler arrays are tiny, so the copy this "optimization" removed saved nothing measurable.

## Verification

- Added a regression test (`__tests__/core/event-handler.test.ts`) reproducing the reentrant-unregister skip. It **fails** on the current code (last handler skipped) and **passes** after the fix.
- Full suite: dev 1070, prod 958, `test:types`, `tsc`, lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)